### PR TITLE
Add ScaleXY for uneven scales

### DIFF
--- a/svg.go
+++ b/svg.go
@@ -99,7 +99,7 @@ func (svg *SVG) Translate(x, y int) { svg.Gtransform(translate(x, y)) }
 // Standard Reference: http://www.w3.org/TR/SVG11/coords.html#TransformAttribute
 func (svg *SVG) Scale(n float64) { svg.Gtransform(scale(n)) }
 
-// Scale scales the coordinate system by dx and dy, end with Gend()
+// ScaleXY scales the coordinate system by dx and dy, end with Gend()
 // Standard Reference: http://www.w3.org/TR/SVG11/coords.html#TransformAttribute
 func (svg *SVG) ScaleXY(dx, dy float64) { svg.Gtransform(scaleXY(dx, dy)) }
 


### PR DESCRIPTION
Hi,

this adds a wrapper for things like s.Gtransform("scale(0.5, 1)")

Please, let me know if I need to add something to this pull request.

Thanks,
Ivan
