### PR TITLE
Hiya--love the library. Was trying to get Textpath to work with a centered textstring...

### DIFF
--- a/svg.go
+++ b/svg.go
@@ -347,10 +347,10 @@ func (svg *SVG) Text(x int, y int, t string, s ...string) {
   svg.Textpath("This is Centered!", "#poly1", `startOffset="50%"`)
   svg.TextEnd()
 */
-func (svg *SVG) TextBegin(s ...string) { svg.println(`<text %s`, endstyle(s, ">")) }
+func (svg *SVG) TextBegin(s ...string) { svg.printf(`<text %s`, endstyle(s, ">")) }
 func (svg *SVG) TextEnd() { svg.println(`</text>`) }
 func (svg *SVG) TextpathInner(t string, pathid string, s ...string) {
-  svg.printf("<textPath xlink:href=\"%s\" %s", endstyle(s, ">"), pathid)
+  svg.printf("<textPath xlink:href=\"%s\" %s", pathid, endstyle(s, ">"))
   xml.Escape(svg.Writer, []byte(t))
   svg.println(`</textPath>`)
 }


### PR DESCRIPTION
and needed better attribute access, so I added an additional TextBegin/TextEnd and TextpathInner. You may have a better implementation approach, but this worked for me. Example usage is in the commit comment.
