### PR TITLE
Add build contrains to exampls to avoid error with App Engine.

### DIFF
--- a/android/android.go
+++ b/android/android.go
@@ -1,3 +1,5 @@
+// +build !appengine
+
 // android draws bugdroid, the Android mascot
 package main
 

--- a/bubtrail/bubtrail.go
+++ b/bubtrail/bubtrail.go
@@ -1,3 +1,5 @@
+// +build !appengine
+
 // bubtrail draws a randmonized trail of bubbles
 package main
 

--- a/bulletgraph/bulletgraph.go
+++ b/bulletgraph/bulletgraph.go
@@ -1,3 +1,5 @@
+// +build !appengine
+
 // bulletgraph - bullet graphs (Design Specification http://www.perceptualedge.com/articles/misc/Bullet_Graph_Design_Spec.pdf)
 package main
 

--- a/codepic/codepic.go
+++ b/codepic/codepic.go
@@ -1,3 +1,5 @@
+// +build !appengine
+
 // codepic -- produce code+output sample suitable for slides
 package main
 

--- a/colortab/colortab.go
+++ b/colortab/colortab.go
@@ -1,3 +1,5 @@
+// +build !appengine
+
 // colortab -- make a color/code placemat
 package main
 

--- a/compx/compx.go
+++ b/compx/compx.go
@@ -1,3 +1,5 @@
+// +build !appengine
+
 // compx: display components and connections on a grid, given a XML description
 package main
 

--- a/f50/f50.go
+++ b/f50/f50.go
@@ -1,3 +1,5 @@
+// +build !appengine
+
 // f50 -- given a search term, display 10x5 image grid, sorted by interestingness
 package main
 

--- a/fe/fe.go
+++ b/fe/fe.go
@@ -1,3 +1,5 @@
+// +build !appengine
+
 // fe: SVG Filter Effect example from http://www.w3.org/TR/SVG/filters.html#AnExample
 package main
 

--- a/flower/flower.go
+++ b/flower/flower.go
@@ -1,3 +1,5 @@
+// +build !appengine
+
 // flower - draw random flowers, inspired by Evelyn Eastmond's DesignBlocks gererated "grain2"
 package main
 

--- a/fontcompare/fontcompare.go
+++ b/fontcompare/fontcompare.go
@@ -1,3 +1,5 @@
+// +build !appengine
+
 // fontcompare: compare two fonts 
 package main
 

--- a/funnel/funnel.go
+++ b/funnel/funnel.go
@@ -1,3 +1,5 @@
+// +build !appengine
+
 // funnel draws a funnel-like shape
 package main
 

--- a/gradient/gradient.go
+++ b/gradient/gradient.go
@@ -1,3 +1,5 @@
+// +build !appengine
+
 // gradient shows sample gradient fills
 package main
 

--- a/html5logo/html5logo.go
+++ b/html5logo/html5logo.go
@@ -1,3 +1,5 @@
+// +build !appengine
+
 // html5logo draws the w3c HTML5 logo, with scripting added
 package main
 

--- a/imfade/imfade.go
+++ b/imfade/imfade.go
@@ -1,3 +1,5 @@
+// +build !appengine
+
 // imfade progressively fades the Go gopher image
 package main
 

--- a/lewitt/lewitt.go
+++ b/lewitt/lewitt.go
@@ -1,3 +1,5 @@
+// +build !appengine
+
 // lewitt: inspired by by Sol LeWitt's Wall Drawing 91:
 package main
 //

--- a/ltr/ltr.go
+++ b/ltr/ltr.go
@@ -1,3 +1,5 @@
+// +build !appengine
+
 // ltr: Layer Tennis remixes
 package main
 

--- a/paths/paths.go
+++ b/paths/paths.go
@@ -1,3 +1,5 @@
+// +build !appengine
+
 // paths draws the W3C logo as a paths
 package main
 

--- a/planets/planets.go
+++ b/planets/planets.go
@@ -1,3 +1,5 @@
+// +build !appengine
+
 // planets: an exploration of scale
 package main
 

--- a/pmap/pmap.go
+++ b/pmap/pmap.go
@@ -1,3 +1,5 @@
+// +build !appengine
+
 // pmap percentage maps
 package main
 

--- a/randcomp/randcomp.go
+++ b/randcomp/randcomp.go
@@ -1,3 +1,5 @@
+// +build !appengine
+
 // randcomp visualizes random number generators
 package main
 

--- a/richter/richter.go
+++ b/richter/richter.go
@@ -1,3 +1,5 @@
+// +build !appengine
+
 // richter -- inspired by Gerhard Richter's 256 colors, 1974
 package main
 

--- a/rl/rl.go
+++ b/rl/rl.go
@@ -1,3 +1,5 @@
+// +build !appengine
+
 // rl - draw random lines
 package main
 

--- a/skewabc/skewabc.go
+++ b/skewabc/skewabc.go
@@ -1,3 +1,5 @@
+// +build !appengine
+
 // skewabc - exercise the skew functions
 package main
 

--- a/stockproduct/stockproduct.go
+++ b/stockproduct/stockproduct.go
@@ -1,3 +1,5 @@
+// +build !appengine
+
 // stockproduct draws a bar chart comparing stock price to products
 package main
 

--- a/svgdef/svgdef.go
+++ b/svgdef/svgdef.go
@@ -1,3 +1,5 @@
+// +build !appengine
+
 // svgdef -  SVG Object Definition and Use
 package main
 

--- a/svgopher/svgopher.go
+++ b/svgopher/svgopher.go
@@ -1,3 +1,5 @@
+// +build !appengine
+
 // svgopher - Go mascot remix
 package main
 

--- a/svgplot/svgplot.go
+++ b/svgplot/svgplot.go
@@ -1,3 +1,5 @@
+// +build !appengine
+
 //svgplot -- plot data (a stream of x,y coordinates)
 package main
 

--- a/svgrid/svgrid.go
+++ b/svgrid/svgrid.go
@@ -1,3 +1,5 @@
+// +build !appengine
+
 // svgrid -- composite SVG files in a grid
 package main
 

--- a/tsg/tsg.go
+++ b/tsg/tsg.go
@@ -1,3 +1,5 @@
+// +build !appengine
+
 // tsg -- twitter search grid
 package main
 

--- a/tumblrgrid/tumblrgrid.go
+++ b/tumblrgrid/tumblrgrid.go
@@ -1,3 +1,5 @@
+// +build !appengine
+
 // tumblrgrid: display a flexible grid of pictures from tumblr, filtered by tags
 package main
 

--- a/turbulence/turbulence.go
+++ b/turbulence/turbulence.go
@@ -1,3 +1,5 @@
+// +build !appengine
+
 // turbulence example from http://www.w3.org/TR/2003/REC-SVG11-20030114/filters.html#feTurbulence
 package main
 

--- a/vismem/vismem.go
+++ b/vismem/vismem.go
@@ -1,3 +1,5 @@
+// +build !appengine
+
 // vismem visualizes memory locations
 package main
 

--- a/webfonts/webfonts.go
+++ b/webfonts/webfonts.go
@@ -1,3 +1,5 @@
+// +build !appengine
+
 // webfonts demo
 package main
 

--- a/websvg/websvg.go
+++ b/websvg/websvg.go
@@ -1,3 +1,5 @@
+// +build !appengine
+
 // websvg draws SVG in a web server
 package main
 


### PR DESCRIPTION
I used svgo with App Engine to [draw braille](http://braille-printer.appspot.com/).
The svgo is great! Many thanks!!

But, I had a problem which cause of App Engine trying import svgo's examples too.
To avoid this I had to remove all examples from svgo for App Engine.

Now, from [App Engine 1.7.4](http://blog.golang.org/2013/01/the-app-engine-sdk-and-workspaces-gopath.html), It is can choose some files
not to be used by App engine with build constraints.

This patch add following build constraints line;

```
// +build !appengine
```

to every examples.
