### PR TITLE
Add <marker> support

### DIFF
--- a/svg.go
+++ b/svg.go
@@ -191,6 +191,10 @@ func (svg *SVG) Def() { svg.println(`<defs>`) }
 // DefEnd ends a defintion block.
 func (svg *SVG) DefEnd() { svg.println(`</defs>`) }
 
+// Markers can be placed on the verticies of lines, polylines, polygons, and paths.
+func (svg *SVG) Marker(s ...string) { svg.printf(`<marker %s`, endstyle(s, ">\n"))  }
+func (svg *SVG) MarkerEnd() { svg.println(`</marker>`)  }
+
 // Desc specified the text of the description tag.
 // Standard Reference: http://www.w3.org/TR/SVG11/struct.html#DescElement
 func (svg *SVG) Desc(s string) { svg.tt("desc", s) }


### PR DESCRIPTION
I needed the <marker> tag but there didn't appear to be support for it so I added it.  If you don't choose to take this change (or some variant of it), can you explain why so I can take it into account in my use of svgo?
