### PR TITLE
make benchviz SVG height calculated from content length

### DIFF
--- a/benchviz/benchviz.go
+++ b/benchviz/benchviz.go
@@ -112,7 +112,6 @@ func (g *geometry) visualize(canvas *svg.SVG, filename string, f io.Reader) int 
 		y += vspacing
 		height = y
 	}
-	//canvas.Rect(0, 0, g.width, g.height, "stroke:lightgray;stroke-width:1;fill:white")
 	canvas.Rect(0, g.top, g.width, height-g.top, "stroke:lightgray;stroke-width:1;fill:none")
 	canvas.Gend()
 


### PR DESCRIPTION
couple of improvement for benchviz:
- make the SVG height calculated from content, aka, auto adjusted based on number of lines
- take out -h command line option
- remove height from geometry
- fix issue with multiple file support
