### PR TITLE
Removes trailing space on SVG namespace

### DIFF
--- a/svg.go
+++ b/svg.go
@@ -54,7 +54,7 @@ const (
 <svg`
 	svginitfmt = `%s width="%d%s" height="%d%s"`
 	svgns      = `
-     xmlns="http://www.w3.org/2000/svg" 
+     xmlns="http://www.w3.org/2000/svg"
      xmlns:xlink="http://www.w3.org/1999/xlink">`
 	vbfmt = `viewBox="%d %d %d %d"`
 


### PR DESCRIPTION
This was causing my end-to-end tests to fail, and adding a space in my test data is inconsistent due to being automatically removed by the IDE.