### PR TITLE
Added Arguments to Textlines to allow free parameters through the lines

### DIFF
--- a/svg.go
+++ b/svg.go
@@ -126,7 +126,7 @@ func (svg *SVG) Startraw(ns ...string) {
 // End the SVG document
 func (svg *SVG) End() { svg.println("</svg>") }
 
-// linkembed defines an element with a specified type, 
+// linkembed defines an element with a specified type,
 // (for example "application/javascript", or "text/css").
 // if the first variadic argument is a link, use only the link reference.
 // Otherwise, treat those arguments as the text of the script (marked up as CDATA).
@@ -420,8 +420,9 @@ func (svg *SVG) Textpath(t string, pathid string, s ...string) {
 
 // Textlines places a series of lines of text starting at x,y, at the specified size, fill, and alignment.
 // Each line is spaced according to the spacing argument
-func (svg *SVG) Textlines(x, y int, s []string, size, spacing int, fill, align string) {
-	svg.Gstyle(fmt.Sprintf("font-size:%dpx;fill:%s;text-anchor:%s", size, fill, align))
+func (svg *SVG) Textlines(x, y int, s []string, size, spacing int, fill, align string, args ...string) {
+	aa := strings.Join(args, "")
+	svg.Gstyle(fmt.Sprintf("font-size:%dpx;fill:%s;text-anchor:%s;%s", size, fill, align, aa))
 	for _, t := range s {
 		svg.Text(x, y, t)
 		y += spacing


### PR DESCRIPTION
Added a single ...args parameter to the end of the *SVG.Textlines func. I then attached the concatenated result to the eng of the gsyle string so additional parameters can be passed through, such s font-family
