### PR TITLE
Remove dependence on ordering of attributes

### DIFF
--- a/svg.go
+++ b/svg.go
@@ -867,7 +867,7 @@ func endstyle(s []string, endtag string) string {
 			if strings.Index(s[i], "=") > 0 {
 				nv += (s[i]) + " "
 			} else {
-				nv += style(s[i])
+				nv += style(s[i]) + " "
 			}
 		}
 		return nv + endtag


### PR DESCRIPTION
When you supply the styling string as an attribute before other attributes the generated SVG will be invalid since a space between the end of the styling string and the name of the following attribute was missing.

The Go code `canvas.Text(100, 100, "Lorem ipsum", "fill: #ff0000;", "text-anchor=\"start\"")` would generate `<text x="100" y="100" style="fill: #ff0000;"text-anchor="start" >Lorem ipsum</text>`, which should be `<text x="100" y="100" style="fill: #ff0000;" text-anchor="start" >Lorem ipsum</text>` with a space between `style="fill: #ff0000;"`and `text-anchor="start"`.