### PR TITLE
Change filter effect flood properties to meet SVG 1.1 spec

### DIFF
--- a/float/svg.go
+++ b/float/svg.go
@@ -656,7 +656,7 @@ func (svg *SVG) FeDistantLight(fs Filterspec, azimuth, elevation float64, s ...s
 // FeFlood specifies a flood filter primitive
 // Standard reference: http://www.w3.org/TR/SVG11/filters.html#feFloodElement
 func (svg *SVG) FeFlood(fs Filterspec, color string, opacity float64, s ...string) {
-	svg.printf(`<feFlood %s flood-fill-color="%s" flood-fill-opacity="%g" %s`,
+	svg.printf(`<feFlood %s flood-color="%s" flood-opacity="%g" %s`,
 		fsattr(fs), color, opacity, endstyle(s, emptyclose))
 }
 

--- a/svg.go
+++ b/svg.go
@@ -633,7 +633,7 @@ func (svg *SVG) FeDistantLight(fs Filterspec, azimuth, elevation float64, s ...s
 // FeFlood specifies a flood filter primitive
 // Standard reference: http://www.w3.org/TR/SVG11/filters.html#feFloodElement
 func (svg *SVG) FeFlood(fs Filterspec, color string, opacity float64, s ...string) {
-	svg.printf(`<feFlood %s flood-fill-color="%s" flood-fill-opacity="%g" %s`,
+	svg.printf(`<feFlood %s flood-color="%s" flood-opacity="%g" %s`,
 		fsattr(fs), color, opacity, endstyle(s, emptyclose))
 }
 


### PR DESCRIPTION
Hello, thank you for this library. While using it, I ran into issues with the feFlood element. Double checking the SVG spec (https://www.w3.org/TR/SVG11/filters.html#feFloodElement), it looks like these properties might be misnamed. Please let me know if I've misunderstood. Thanks.